### PR TITLE
feat: Parse parameters from external txt file when exif metadata is missing

### DIFF
--- a/crawler/parser.js
+++ b/crawler/parser.js
@@ -20,6 +20,20 @@ class Parser {
     return { ...attrs, ...this.getMeta(parsed), app }
   }
 
+  async parseParametersText(parsed, parametersText) {
+
+    const metadata = this.getMeta({
+      ...parsed,
+      parameters: parametersText
+    })
+
+    if (!metadata) {
+      return parsed;
+    }
+
+    return { ...metadata, app: "automatic1111" }
+  }
+
   convert(e, options) {
   /*
   automatic111 {
@@ -182,7 +196,7 @@ class Parser {
       "xmp:agent",
       "dc:subject"
     ]
-    
+
     let list = []
     for(let key of keys) {
       if (x[key]) {

--- a/crawler/standard.js
+++ b/crawler/standard.js
@@ -18,8 +18,23 @@ class Standard {
       if (!info.parsed || force) {
         let buf = await fs.promises.readFile(filename)
         let parsed = await parser.parse(buf)
+
+        if (!parsed.app) {
+          // no app found => try parse from external txt file
+          const parametersFilename = path.join(path.dirname(filename), path.basename(filename, path.extname(filename)) + '.txt');
+
+          try {
+            let parametersText = await fs.promises.readFile(parametersFilename, 'utf8')
+            parsed = await parser.parseParametersText(parsed, parametersText);
+          } catch (e) {
+            if (e.code !== 'ENOENT') {
+              throw e;
+            }
+          }
+        }
+
         let list = parser.convert(parsed)
-        await this.gm.set(filename, list) 
+        await this.gm.set(filename, list)
       }
 
       let serialized = await parser.serialize(this.folderpath, filename)


### PR DESCRIPTION
Currently only supports automatic1111, unsure if other projects support creating metadata text files alongside the images.

Closes #14